### PR TITLE
feat(inventory): add financial metrics, Excel export, and in-page editing

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,7 +95,7 @@ jobs:
     name: Deploy (needs build jobs)
     needs: [build-frontend, build-backend]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment: production                   # <- 可選：若要使用 Environment 的審核機制
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,10 +1,17 @@
 name: Cheng-Vue CI/CD
 
 on:
+  # 只在直接推送到 main 分支時觸發
   push:
-    branches: [ main, master ]
+    branches:
+      - 'main'
+      - 'master'
+  # 只在 PR 開啟、同步 (推送新 commit) 或重開時觸發
   pull_request:
-    branches: [ "main", "master" ]
+    types: [ opened, synchronize, reopened ]
+    branches:
+      - 'main'
+      - 'master'
   workflow_dispatch:
 
 concurrency:

--- a/cheng-system/src/main/java/com/cheng/system/dto/InvItemWithStockDTO.java
+++ b/cheng-system/src/main/java/com/cheng/system/dto/InvItemWithStockDTO.java
@@ -1,5 +1,6 @@
 package com.cheng.system.dto;
 
+import com.cheng.common.annotation.Excel;
 import lombok.Data;
 
 import java.io.Serial;
@@ -28,11 +29,13 @@ public class InvItemWithStockDTO implements Serializable {
     /**
      * 物品編碼
      */
+    @Excel(name = "物品編碼")
     private String itemCode;
 
     /**
      * 物品名稱
      */
+    @Excel(name = "物品名稱")
     private String itemName;
 
     /**
@@ -43,11 +46,13 @@ public class InvItemWithStockDTO implements Serializable {
     /**
      * 分類名稱
      */
+    @Excel(name = "分類")
     private String categoryName;
 
     /**
      * 條碼
      */
+    @Excel(name = "條碼")
     private String barcode;
 
     /**
@@ -58,51 +63,61 @@ public class InvItemWithStockDTO implements Serializable {
     /**
      * 規格
      */
+    @Excel(name = "規格")
     private String specification;
 
     /**
      * 單位
      */
+    @Excel(name = "單位")
     private String unit;
 
     /**
      * 品牌
      */
+    @Excel(name = "品牌")
     private String brand;
 
     /**
      * 型號
      */
+    @Excel(name = "型號")
     private String model;
 
     /**
      * 採購價格
      */
+    @Excel(name = "採購價格")
     private BigDecimal purchasePrice;
 
     /**
      * 現價
      */
+    @Excel(name = "現價")
     private BigDecimal currentPrice;
 
     /**
      * 供應商
      */
+    @Excel(name = "供應商")
     private String supplier;
 
     /**
      * 最低庫存
      */
+    @Excel(name = "最低庫存")
     private Integer minStock;
 
     /**
      * 最高庫存
      */
+    @Excel(name = "最高庫存")
     private Integer maxStock;
 
     /**
      * 存放位置
      */
+    @Excel(name = "存放位置")
     private String location;
 
     /**
@@ -134,36 +149,43 @@ public class InvItemWithStockDTO implements Serializable {
     /**
      * 總數量
      */
+    @Excel(name = "總數量")
     private Integer totalQuantity;
 
     /**
      * 可用數量
      */
+    @Excel(name = "可用數量")
     private Integer availableQty;
 
     /**
      * 借出數量
      */
+    @Excel(name = "借出數量")
     private Integer borrowedQty;
 
     /**
      * 預留數量
      */
+    @Excel(name = "預留數量")
     private Integer reservedQty;
 
     /**
      * 損壞數量
      */
+    @Excel(name = "損壞數量")
     private Integer damagedQty;
 
     /**
      * 最後入庫時間
      */
+    @Excel(name = "最後入庫時間", width = 30, dateFormat = "yyyy-MM-dd HH:mm:ss")
     private Date lastInTime;
 
     /**
      * 最後出庫時間
      */
+    @Excel(name = "最後出庫時間", width = 30, dateFormat = "yyyy-MM-dd HH:mm:ss")
     private Date lastOutTime;
 
     /**
@@ -180,6 +202,7 @@ public class InvItemWithStockDTO implements Serializable {
     /**
      * 庫存狀態文字
      */
+    @Excel(name = "庫存狀態")
     private String stockStatusText;
 
     /**
@@ -188,9 +211,28 @@ public class InvItemWithStockDTO implements Serializable {
     private Boolean isBelowMinStock;
 
     /**
-     * 庫存總價值
+     * 庫存總價值（現價 × 總數量）
      */
+    @Excel(name = "庫存總價值")
     private BigDecimal stockValue;
+
+    /**
+     * 成本總價值（採購價 × 總數量）
+     */
+    @Excel(name = "成本總價值")
+    private BigDecimal costValue;
+
+    /**
+     * 預期利潤（庫存總價值 - 成本總價值）
+     */
+    @Excel(name = "預期利潤")
+    private BigDecimal expectedProfit;
+
+    /**
+     * 利潤率（%）
+     */
+    @Excel(name = "利潤率")
+    private BigDecimal profitRate;
 
     /**
      * 計算庫存狀態
@@ -220,11 +262,29 @@ public class InvItemWithStockDTO implements Serializable {
     }
 
     /**
-     * 計算庫存總價值
+     * 計算庫存總價值和財務指標
      */
     public void calculateStockValue() {
         if (currentPrice != null && totalQuantity != null) {
+            // 庫存總價值 = 現價 × 總數量
             this.stockValue = currentPrice.multiply(BigDecimal.valueOf(totalQuantity));
+        }
+
+        if (purchasePrice != null && totalQuantity != null) {
+            // 成本總價值 = 採購價 × 總數量
+            this.costValue = purchasePrice.multiply(BigDecimal.valueOf(totalQuantity));
+        }
+
+        // 計算預期利潤
+        if (stockValue != null && costValue != null) {
+            this.expectedProfit = stockValue.subtract(costValue);
+        }
+
+        // 計算利潤率
+        if (currentPrice != null && purchasePrice != null && purchasePrice.compareTo(BigDecimal.ZERO) > 0) {
+            BigDecimal priceDiff = currentPrice.subtract(purchasePrice);
+            this.profitRate = priceDiff.divide(purchasePrice, 4, BigDecimal.ROUND_HALF_UP)
+                    .multiply(BigDecimal.valueOf(100));
         }
     }
 

--- a/cheng-system/src/main/resources/mapper/system/InvItemMapper.xml
+++ b/cheng-system/src/main/resources/mapper/system/InvItemMapper.xml
@@ -286,6 +286,10 @@ PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
             <if test="supplier != null">supplier = #{supplier},</if>
             <if test="purchasePrice != null">purchase_price = #{purchasePrice},</if>
             <if test="currentPrice != null">current_price = #{currentPrice},</if>
+            <if test="minStock != null">min_stock = #{minStock},</if>
+            <if test="maxStock != null">max_stock = #{maxStock},</if>
+            <if test="location != null">location = #{location},</if>
+            <if test="description != null">description = #{description},</if>
             <if test="imageUrl != null">image_url = #{imageUrl},</if>
             <if test="barcode != null">barcode = #{barcode},</if>
             <if test="qrCode != null">qr_code = #{qrCode},</if>


### PR DESCRIPTION
新增庫存財務指標計算、Excel匯出及頁內編輯功能

- 後端增強 (Backend):
    - 在庫存物品 DTO (InvItemWithStockDTO) 中新增財務相關欄位，包含「成本總價值」、「預期利潤」與「利潤率」。
    - 擴充計算邏輯，可自動計算上述財務指標。
    - 為 DTO 內所有欄位加上 @Excel 註解，為後續的 Excel 匯出功能做準備。
    - 更新 Mapper XML，允許在編輯物品時更新更多欄位，如最低/最高庫存、存放位置等。

- 前端優化 (Frontend):
    - 將「修改」功能從跳轉至新頁面，改為在當前頁面彈出對話框進行編輯，提升使用者體驗。
    - 在物品詳情面板中，新增並美化財務指標的顯示，使用不同顏色突顯利潤狀態，並格式化貨幣與百分比。
    - 新增金額與百分比的格式化工具函數。
    - 調整庫存列表的部分欄位寬度，並移除較不重要的「單位」欄位以簡化版面。